### PR TITLE
Prevent crashes when trying to get null data

### DIFF
--- a/zk.go
+++ b/zk.go
@@ -511,8 +511,11 @@ func (conn *Conn) Get(path string) (data string, stat *Stat, err error) {
 		return "", nil, zkError(rc, cerr, "get", path)
 	}
 
-	result := C.GoStringN(cbuffer, cbufferLen)
-	return result, &cstat, nil
+	result := ""
+	if cbufferLen != -1 {
+		result = C.GoStringN(cbuffer, cbufferLen)
+	}
+	return result, &cstat, watchChannel, nil
 }
 
 // GetW works like Get but also returns a channel that will receive
@@ -541,7 +544,10 @@ func (conn *Conn) GetW(path string) (data string, stat *Stat, watch <-chan Event
 		return "", nil, nil, zkError(rc, cerr, "getw", path)
 	}
 
-	result := C.GoStringN(cbuffer, cbufferLen)
+	result := ""
+	if cbufferLen != -1 {
+		result = C.GoStringN(cbuffer, cbufferLen)
+	}
 	return result, &cstat, watchChannel, nil
 }
 


### PR DESCRIPTION
Gozk crashes when a Java-based client create a null zknode; e.g. `create
/mynode` using zkCli.sh.  This patch, sourced from
https://bugs.launchpad.net/gozk/+bug/1302789, fixes this problem.
From the description there, zoo_wget returns -1 in buffer_len, which is
interpreted as a very large string size, which leads to OOM.  This patch
returns an empty string if the znode is zero size, and the actual data
otherwise.

cc @pushrax @wvanbergen @marc-barry 