### PR TITLE
bug fix

### DIFF
--- a/zk.go
+++ b/zk.go
@@ -515,7 +515,7 @@ func (conn *Conn) Get(path string) (data string, stat *Stat, err error) {
 	if cbufferLen != -1 {
 		result = C.GoStringN(cbuffer, cbufferLen)
 	}
-	return result, &cstat, watchChannel, nil
+	return result, &cstat, nil
 }
 
 // GetW works like Get but also returns a channel that will receive


### PR DESCRIPTION
```
elvinefendi@Elvins-Pro magellan (update-gozk)$ godep get github.com/Shopify/gozk-recipes/session
# github.com/Shopify/gozk
../gozk/zk.go:518: undefined: watchChannel
../gozk/zk.go:518: too many arguments to return
godep: exit status 2
```

`watchChannel` variable seems to be redundant in the `return` statement.

r: @andrewjamesbrown 
@Shopify/traffic 