### PR TITLE
Add ability to serialize ClientId

### DIFF
--- a/zk.go
+++ b/zk.go
@@ -894,6 +894,8 @@ func buildACLVector(aclv []ACL) *C.struct_ACL_vector {
 	return caclv
 }
 
+const offsetClientIdPasswd = 8
+
 func LoadClientId(b []byte) (*ClientId, error) {
 	c := &ClientId{}
 
@@ -903,7 +905,7 @@ func LoadClientId(b []byte) (*ClientId, error) {
 
 	c.cId.client_id = C.int64_t(binary.BigEndian.Uint64(b))
 	for i := uintptr(0); i < unsafe.Sizeof(c.cId.passwd); i++ {
-		c.cId.passwd[i] = C.char(b[8+i])
+		c.cId.passwd[i] = C.char(b[offsetClientIdPasswd+i])
 	}
 	return c, nil
 }

--- a/zk.go
+++ b/zk.go
@@ -18,6 +18,9 @@ package zookeeper
 import "C"
 
 import (
+	"bytes"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -889,6 +892,29 @@ func buildACLVector(aclv []ACL) *C.struct_ACL_vector {
 	}
 
 	return caclv
+}
+
+func LoadClientId(b []byte) (*ClientId, error) {
+	c := &ClientId{}
+
+	if uintptr(len(b)) != unsafe.Sizeof(c.cId) {
+		return nil, errors.New("client id size mismatch")
+	}
+
+	c.cId.client_id = C.int64_t(binary.BigEndian.Uint64(b))
+	for i := uintptr(0); i < unsafe.Sizeof(c.cId.passwd); i++ {
+		c.cId.passwd[i] = C.char(b[8+i])
+	}
+	return c, nil
+}
+
+func (c *ClientId) Save() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	err := binary.Write(buf, binary.BigEndian, c.cId)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // -----------------------------------------------------------------------

--- a/zk_test.go
+++ b/zk_test.go
@@ -2,8 +2,8 @@ package zookeeper_test
 
 import (
 	"errors"
-	. "launchpad.net/gocheck"
 	zk "github.com/Shopify/gozk"
+	. "launchpad.net/gocheck"
 	"time"
 )
 
@@ -528,6 +528,19 @@ func (s *S) TestClientIdAndReInit(c *C) {
 	clientId2 := zk2.ClientId()
 
 	c.Assert(clientId1, DeepEquals, clientId2)
+}
+
+func (s *S) TestClientIdSerialization(c *C) {
+	zk1, _ := s.init(c)
+	clientId1 := zk1.ClientId()
+
+	b, _ := clientId1.Save()
+	clientId2, _ := zk.LoadClientId(b)
+	c.Assert(clientId1, DeepEquals, clientId2)
+
+	zk2, _, err := zk.Redial(s.zkAddr, 5e9, clientId2)
+	c.Assert(err, IsNil)
+	defer zk2.Close()
 }
 
 // Surprisingly for some (including myself, initially), the watch


### PR DESCRIPTION
@katdrobnjakovic, @andrewjamesbrown, @sirupsen 

One of the first things required for https://github.com/Shopify/magellan/pull/105#issuecomment-270804558.

This adds the ability to serialize and deserialize Zookeeper client ids so that a session can be resumed when a process restarts. 

We don't have any CI for this, but I manually ran the tests in my own dev environment (on Linux, because I couldn't get this working in OSX).