### PR TITLE
Fix memory leak for empty string vectors

### DIFF
--- a/zk.go
+++ b/zk.go
@@ -574,6 +574,8 @@ func (conn *Conn) Children(path string) (children []string, stat *Stat, err erro
 	if cvector.count != 0 {
 		children = parseStringVector(&cvector)
 	}
+	C.deallocate_String_vector(cvector)
+
 	if rc == C.ZOK {
 		stat = &cstat
 	} else {
@@ -606,6 +608,8 @@ func (conn *Conn) ChildrenW(path string) (children []string, stat *Stat, watch <
 	if cvector.count != 0 {
 		children = parseStringVector(&cvector)
 	}
+	C.deallocate_String_vector(cvector)
+
 	if rc == C.ZOK {
 		stat = &cstat
 		watch = watchChannel
@@ -625,7 +629,6 @@ func parseStringVector(cvector *C.struct_String_vector) []string {
 		cpath := *(**C.char)(unsafe.Pointer(cpathPos))
 		vector[i] = C.GoString(cpath)
 	}
-	C.deallocate_String_vector(cvector)
 	return vector
 }
 

--- a/zk.go
+++ b/zk.go
@@ -567,7 +567,7 @@ func (conn *Conn) Children(path string) (children []string, stat *Stat, err erro
 	defer C.free(unsafe.Pointer(cpath))
 
 	cvector := C.struct_String_vector{}
-	defer C.deallocate_String_vector(cvector)
+	defer C.deallocate_String_vector(&cvector)
 
 	var cstat Stat
 	rc, cerr := C.zoo_wget_children2(conn.handle, cpath, nil, nil, &cvector, &cstat.c)
@@ -601,7 +601,7 @@ func (conn *Conn) ChildrenW(path string) (children []string, stat *Stat, watch <
 	watchId, watchChannel := conn.createWatch(true)
 
 	cvector := C.struct_String_vector{}
-	defer C.deallocate_String_vector(cvector)
+	defer C.deallocate_String_vector(&cvector)
 
 	var cstat Stat
 	rc, cerr := C.zoo_wget_children2_int(conn.handle, cpath, C.watch_handler, C.ulong(watchId), &cvector, &cstat.c)

--- a/zk.go
+++ b/zk.go
@@ -567,6 +567,8 @@ func (conn *Conn) Children(path string) (children []string, stat *Stat, err erro
 	defer C.free(unsafe.Pointer(cpath))
 
 	cvector := C.struct_String_vector{}
+	defer C.deallocate_String_vector(cvector)
+
 	var cstat Stat
 	rc, cerr := C.zoo_wget_children2(conn.handle, cpath, nil, nil, &cvector, &cstat.c)
 
@@ -574,8 +576,6 @@ func (conn *Conn) Children(path string) (children []string, stat *Stat, err erro
 	if cvector.count != 0 {
 		children = parseStringVector(&cvector)
 	}
-	C.deallocate_String_vector(cvector)
-
 	if rc == C.ZOK {
 		stat = &cstat
 	} else {
@@ -601,6 +601,8 @@ func (conn *Conn) ChildrenW(path string) (children []string, stat *Stat, watch <
 	watchId, watchChannel := conn.createWatch(true)
 
 	cvector := C.struct_String_vector{}
+	defer C.deallocate_String_vector(cvector)
+
 	var cstat Stat
 	rc, cerr := C.zoo_wget_children2_int(conn.handle, cpath, C.watch_handler, C.ulong(watchId), &cvector, &cstat.c)
 
@@ -608,8 +610,6 @@ func (conn *Conn) ChildrenW(path string) (children []string, stat *Stat, watch <
 	if cvector.count != 0 {
 		children = parseStringVector(&cvector)
 	}
-	C.deallocate_String_vector(cvector)
-
 	if rc == C.ZOK {
 		stat = &cstat
 		watch = watchChannel


### PR DESCRIPTION
This fixes what was a long standing memory leak in the Gozk client. This was a team effort between me, @kirs and @hkdsun.

We'd seen a memory leak in one of our internal services that is a heavy Zookeeper client. Using [bcc](https://github.com/iovisor/bcc/) tooling, we used the [memleak.py](https://github.com/iovisor/bcc/blob/master/tools/memleak.py) script to track memory allocations on the service process. We used a 30 seconds interval to capture a large number of allocations, along with the `-o` option to prune any allocations newer than 5000ms (to try to remove as much noise as possible):
```
memleak-bpfcc -p 1174052 -o 5000 30
Attaching to pid 1174052, Ctrl+C to quit.
[17:34:55] Top 10 stacks with outstanding allocations:
    0 bytes in 6261 allocations from stack
        deserialize_String_vector+0x4c [libzookeeper_mt.so.2.0.0]
        deserialize_GetChildren2Response+0x4b [libzookeeper_mt.so.2.0.0]
        process_sync_completion+0x27e [libzookeeper_mt.so.2.0.0]
        zookeeper_process+0x5e7 [libzookeeper_mt.so.2.0.0]
        do_io+0x277 [libzookeeper_mt.so.2.0.0]
        start_thread+0xdb [libpthread-2.27.so]
```

We initially thought that a 0 byte allocation was a bug in the tool. However, after taking a look at the [libzookeeper-mt source](https://packages.ubuntu.com/xenial/libzookeeper-mt-dev), we discovered that it's possible.

The function performing the allocation is in [generated code](https://github.com/apache/zookeeper/blob/release-3.4.8/src/zookeeper.jute#L202-L205) that deserializes a string vector from a response to the `GetChildren2` API:
```c
int deserialize_String_vector(struct iarchive *in, const char *tag, struct String_vector *v)
{
    int rc = 0;
    int32_t i;
    rc = in->start_vector(in, tag, &v->count);
    v->data = calloc(v->count, sizeof(*v->data));
    for(i=0;i<v->count;i++) {
    rc = rc ? rc : in->deserialize_String(in, "value", &v->data[i]);
    }
    rc = in->end_vector(in, tag);
    return rc;
}
```
From the code, you can see that the deserialization function will perform an allocation, even if the number of elements in the vector is 0. After looking at this, I immediately looked at the function that deallocates a string vector to ensure that it's always freeing the memory (even if the size is 0):
```c
int deallocate_String_vector(struct String_vector *v) {
    if (v->data) {
        int32_t i;
        for(i=0;i<v->count; i++) {
            deallocate_String(&v->data[i]);
        }
        free(v->data);
        v->data = 0;
    }
    return 0;
}
```

Sure enough, this code is checking that `v->data` is non-`NULL`, so this should be working as expected. 

The memory was being allocated by `deserialize_GetChildren2Response`. My next step was to find all calls to the corresponding `deallocate_GetChildren2Response`, which is responsible for freeing the `GetChildren2Response` struct. The interesting hit that came back was https://github.com/apache/zookeeper/blob/release-3.4.8/src/c/src/zookeeper.c#L1941-L1942:
```c
            /* We don't deallocate since we are passing it back */
            // deallocate_GetChildren2Response(&res);
```

If you look at the preceding code, you can see that the response is not being freed because ownership of the `res.children` and `res.stat` pointers are being transferred to the `sync_completion` pointer passed into `process_sync_completion`. So from here I started to look to see if there was anything that was calling `deallocate_String_vector` (trying to locate who would actually deallocate these pointers). This led me to https://github.com/apache/zookeeper/blob/release-3.4.8/src/c/src/zookeeper.c#L3625:
```c
        if (rc == 0) {
            *stat = sc->u.strs_stat.stat2;
            if (strings) {
                *strings = sc->u.strs_stat.strs2;
            } else {
                deallocate_String_vector(&sc->u.strs_stat.strs2);
            }
        }
```

Looking at where this function was called, `zoo_wget_children_`, led me to believe that freeing string vectors was likely done as a result of GetChildren calls. 

At this point, I took a bit of a jump. Knowing that our service is using the `gozk` library, I started to look at see how it implements the `GetChildren` API. This is what led me to the smoking gun https://github.com/Shopify/gozk/blob/44ac27c2604acead0f08c20e83a448e282d29d9c/zk.go#L571-L574:

```go
	rc, cerr := C.zoo_wget_children2(conn.handle, cpath, nil, nil, &cvector, &cstat.c)

	// Can't happen if rc != 0, but avoid potential memory leaks in the future.
	if cvector.count != 0 {
		children = parseStringVector(&cvector)
	}
```
Looking at the implementation of `parseStringVector`, you can see that it's responsible for calling `deallocate_String_vector`:
```go
func parseStringVector(cvector *C.struct_String_vector) []string {
	vector := make([]string, cvector.count)
	dataStart := uintptr(unsafe.Pointer(cvector.data))
	uintptrSize := unsafe.Sizeof(dataStart)
	for i := 0; i != len(vector); i++ {
		cpathPos := dataStart + uintptr(i)*uintptrSize
		cpath := *(**C.char)(unsafe.Pointer(cpathPos))
		vector[i] = C.GoString(cpath)
	}
	C.deallocate_String_vector(cvector)
	return vector
}
```

So you can see what the problem is: we are only calling `parseStringVector` when `cvector.count != 0`. As a result, in the cases where there is an empty string vector returned by `zoo_wget_children2`, we never free the 0-byte allocation.

The fix that I've made here removes the `deallocate_String_vector` call from `parseStringVector`, moving the responsibility of freeing the vector up to the caller. This should be safe in all cases. We're default initializing `cvector`, so its `data` member will be `NULL`. So even if it's never touched by `zoo_wget_children2`, it's still safe to call `deallocate_String_vector`.