### PR TITLE
Documenting build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _*
 [568].out
 *.cgo*.c
 *.cgo*.go
+tags

--- a/README
+++ b/README
@@ -1,4 +1,0 @@
-Check out https://wiki.ubuntu.com/gozk
-
-Forked from https://github.com/youtube/vitess/tree/master/third_party/go/launchpad.net/gozk/zookeeper
-to fix panic issues in some of the watch functions.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# gozk - Go zookeeper library via C bindings
+
+Forked from https://github.com/youtube/vitess/tree/master/third_party/go/launchpad.net/gozk/zookeeper
+
+## Requirements
+
+- zookeeper c library headers: when installed via homebrew you'll find the includes under `/opt/homebrew/include` and the shared libraries in `/opt/homebrew/lib/`. Other
+  systems such as Linux use different paths but are likely to place them under `/usr/include` and `/usr/lib`.
+- C compiler
+
+The default flags defined in zk.go **should be sufficient** for builds on Linux or MacOSX. But If you zookeeper includes and shared libraries are not in the default
+search locations (`/usr/include` and `/usr/lib`) you'll have to set environment variables to point the compiler at the right path. For example when using homebrew,
+you'll need to specify:
+
+```
+export CGO_CFLAGS='-I/opt/homebrew/include/zookeeper'
+export CGO_LDFLAGS='-L/opt/homebrew/lib'
+```
+
+On Debian Linux, used by the official go docker container, you'll needthe following libraries:
+
+* `libzookeeper-mt-dev`: header files
+* `libzookeeper-mt2`: shared libraries
+
+Set the `CGO` flags:
+
+```
+export CGO_CFLAGS='-I/usr/include/zookeeper'
+export CGO_LDFLAGS='-L/usr/lib/aarch64-linux-gnu'
+```
+
+Then:
+
+```
+go build
+```
+
+### Build Errors
+
+#### `zookeeper.h` not found
+Error message looks like this:
+```
+./zk.go:21:11: fatal error: zookeeper.h: No such file or directory
+   21 | // #include <zookeeper.h>
+      |           ^~~~~~~~~~~~~
+compilation terminated.
+```
+
+The include search path does not include the zookeeper includes. Check that `CGO_CFLAGS=-I` is set to a directory that contains the zookeeper includes.
+
+#### `ld: library not found`
+Error message:
+```
+ld: library not found for -lzookeeper_mt
+collect2: error: ld returned 1 exit status
+```
+
+The linker can't find the shared library. Ensure that `CGO_LDFLAGS=-L` points to a directory that contains the zookeeper libraries.
+
+## Historic Notes
+
+Check out https://wiki.ubuntu.com/gozk
+
+Forked from https://github.com/youtube/vitess/tree/master/third_party/go/launchpad.net/gozk/zookeeper
+to fix panic issues in some of the watch functions.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/Shopify/gozk
+
+go 1.16
+
+require launchpad.net/gocheck v0.0.0-20140225173054-000000000087

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=

--- a/zk.go
+++ b/zk.go
@@ -8,13 +8,13 @@
 //
 package zookeeper
 
-/*
-#cgo CFLAGS: -I/usr/include/c-client-src -I/usr/include/zookeeper
-#cgo LDFLAGS: -lzookeeper_mt
-
-#include <zookeeper.h>
-#include "helpers.h"
-*/
+// #cgo CFLAGS: -DTHREADED -I/usr/include/zookeeper
+// #cgo darwin CFLAGS: -DTHREADED -I/opt/homebrew/include/zookeeper
+// #cgo LDFLAGS: -lzookeeper_mt
+// #cgo darwin LDFLAGS: -L/opt/homebrew/lib
+//
+// #include <zookeeper.h>
+// #include "helpers.h"
 import "C"
 
 import (


### PR DESCRIPTION
Building this library started breaking when we introduced the M1
laptops. Initially it appeared to be an issue with the new instruction
set, however, builds failed on linux as well. The main issue was that
the build procedure was not properly documented.

Due to that, header files and shared libraries could not be found, and
even after rectifying this, a preprocessor define (`THREADED`) was
missing the compiler couldn't resolve all the symbols.

This commit updates the README with necessary instructions on how to
build, and adds CGO flags specifically for building on the new M1
macbooks.  Further it adds a `go.mod` file to properly declare
dependencies.