### PR TITLE
bring golang to 1.22 version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/Shopify/gozk
 
-go 1.14
+go 1.22
 
 require launchpad.net/gocheck v0.0.0-20140225173054-000000000087


### PR DESCRIPTION
Updated golang to version 1.22.

I pointed Magellan to this commit and it passes its tests locally